### PR TITLE
Simplify local includes of Header Files.

### DIFF
--- a/src/blink_led_hw/Makefile
+++ b/src/blink_led_hw/Makefile
@@ -1,4 +1,4 @@
-include ../Makefile.inc
+include ${CURDIR}/../Makefile.inc
 
 PROG=main
 SRCS=$(PROG).c

--- a/src/blink_led_sw/Makefile
+++ b/src/blink_led_sw/Makefile
@@ -1,4 +1,4 @@
-include ../Makefile.inc
+include ${CURDIR}/../Makefile.inc
 
 PROG=main
 SRCS=$(PROG).c

--- a/src/ds_1307/Makefile
+++ b/src/ds_1307/Makefile
@@ -1,11 +1,18 @@
-include ../Makefile.inc
+include ${CURDIR}/../Makefile.inc
 
 PROG=main
+
+I2C=	$(TOP)/sw_i2c
+UART=	$(TOP)/hw_uart
+UTIL=	$(TOP)/util
+
 SRCS=$(PROG).c \
      ds1307.c \
-     $(TOP)/hw_uart/uart.c \
-     $(TOP)/sw_i2c/i2c.c \
-     $(TOP)/util/util.c
+     $(I2C)/i2c.c \
+     $(UART)/uart.c \
+     $(UTIL)/util.c
+
+CFLAGS+= -I${I2C} -I${UART} -I${UTIL}
 
 CLEANFILES=$(PROG).hex $(PROG).out
 

--- a/src/ds_1307/ds1307.c
+++ b/src/ds_1307/ds1307.c
@@ -18,8 +18,8 @@
 #include <avr/io.h>
 
 #include "ds1307.h"
-#include "sw_i2c/i2c.h"
-#include "util/util.h"
+#include "i2c.h"
+#include "util.h"
 
 struct rtc_tm ds1307_tm;
 

--- a/src/ds_1307/main.c
+++ b/src/ds_1307/main.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 Sebastian Trahm
+ * Copyright (c) 2012-2013 Sebastian Trahm
  * All rights reserved.
  *
  * Permission to use, copy, modify, and distribute this software for any
@@ -25,8 +25,8 @@
 
 #include "board.h"
 #include "ds1307.h"
-#include "hw_uart/uart.h"
-#include "sw_i2c/i2c.h"
+#include "i2c.h"
+#include "uart.h"
 
 #define BAUDRATE	38400
 #define BUFFER_SIZE	32

--- a/src/ds_1631/Makefile
+++ b/src/ds_1631/Makefile
@@ -1,11 +1,18 @@
-include ../Makefile.inc
+include ${CURDIR}/../Makefile.inc
 
 PROG=main
+
+I2C=	$(TOP)/sw_i2c
+UART=	$(TOP)/hw_uart
+UTIL=	$(TOP)/util
+
 SRCS=$(PROG).c \
      ds1631.c \
-     $(TOP)/hw_uart/uart.c \
-     $(TOP)/sw_i2c/i2c.c \
-     $(TOP)/util/util.c
+     $(I2C)/i2c.c \
+     $(UART)/uart.c \
+     $(UTIL)/util.c
+
+CFLAGS+= -I${I2C} -I${UART} -I${UTIL}
 
 CLEANFILES=$(PROG).hex $(PROG).out
 

--- a/src/ds_1631/ds1631.c
+++ b/src/ds_1631/ds1631.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2012 Sebastian Trahm
+ * Copyright (c) 2011-2013 Sebastian Trahm
  * All rights reserved.
  *
  * Permission to use, copy, modify, and distribute this software for any
@@ -18,8 +18,8 @@
 #include <avr/io.h>
 
 #include "ds1631.h"
-#include "sw_i2c/i2c.h"
-#include "util/util.h"
+#include "i2c.h"
+#include "util.h"
 
 struct ds1631_temperature ds1631_struct;
 

--- a/src/ds_1631/ds1631.h
+++ b/src/ds_1631/ds1631.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2012 Sebastian Trahm
+ * Copyright (c) 2011-2013 Sebastian Trahm
  * All rights reserved.
  *
  * Permission to use, copy, modify, and distribute this software for any

--- a/src/ds_1631/main.c
+++ b/src/ds_1631/main.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2012 Sebastian Trahm
+ * Copyright (c) 2011-2013 Sebastian Trahm
  * All rights reserved.
  *
  * Permission to use, copy, modify, and distribute this software for any
@@ -25,8 +25,8 @@
 
 #include "board.h"
 #include "ds1631.h"
-#include "hw_uart/uart.h"
-#include "sw_i2c/i2c.h"
+#include "i2c.h"
+#include "uart.h"
 
 #define BAUDRATE	38400
 #define BUFFER_SIZE	48

--- a/src/hw_i2c/Makefile
+++ b/src/hw_i2c/Makefile
@@ -1,9 +1,13 @@
-include ../Makefile.inc
+include ${CURDIR}/../Makefile.inc
 
 PROG=main
+UART=	$(TOP)/hw_uart
+
 SRCS=$(PROG).c \
-     $(TOP)/hw_uart/uart.c \
-     i2c.c
+     i2c.c \
+     $(UART)/uart.c
+
+CFLAGS+= -I${UART}
 
 CLEANFILES=$(PROG).hex $(PROG).out
 

--- a/src/hw_i2c/main.c
+++ b/src/hw_i2c/main.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 Sebastian Trahm
+ * Copyright (c) 2012-2013 Sebastian Trahm
  * All rights reserved.
  *
  * Permission to use, copy, modify, and distribute this software for any
@@ -19,7 +19,7 @@
 #include <avr/interrupt.h>
 
 #include "board.h"
-#include "hw_uart/uart.h"
+#include "uart.h"
 #include "i2c.h"
 
 #define BAUDRATE	38400

--- a/src/hw_uart/Makefile
+++ b/src/hw_uart/Makefile
@@ -1,4 +1,4 @@
-include ../Makefile.inc
+include ${CURDIR}/../Makefile.inc
 
 PROG=main
 SRCS=$(PROG).c \

--- a/src/nto_nunchuk/Makefile
+++ b/src/nto_nunchuk/Makefile
@@ -1,10 +1,16 @@
-include ../Makefile.inc
+include ${CURDIR}/../Makefile.inc
 
 PROG=main
+
+I2C=	$(TOP)/sw_i2c
+UART=	$(TOP)/hw_uart
+
 SRCS=$(PROG).c \
-     nunchuk.c \
-     $(TOP)/hw_uart/uart.c \
-     $(TOP)/sw_i2c/i2c.c
+     $(I2C)/i2c.c \
+     $(UART)/uart.c \
+     nunchuk.c
+
+CFLAGS+= -I${I2C} -I${UART}
 
 CLEANFILES=$(PROG).hex $(PROG).out
 

--- a/src/nto_nunchuk/main.c
+++ b/src/nto_nunchuk/main.c
@@ -23,9 +23,9 @@
 
 #include <util/delay.h>
 
-#include "hw_uart/uart.h"
-#include "sw_i2c/i2c.h"
+#include "i2c.h"
 #include "nunchuk.h"
+#include "uart.h"
 
 #define BUFFER_SIZE	80
 #define BAUDRATE	115200

--- a/src/nto_nunchuk/nunchuk.c
+++ b/src/nto_nunchuk/nunchuk.c
@@ -19,7 +19,7 @@
 
 #include <util/delay.h>
 
-#include "sw_i2c/i2c.h"
+#include "i2c.h"
 #include "nunchuk.h"
 
 struct nunchuk_tm nunchukData;

--- a/src/pcd_8544/Makefile
+++ b/src/pcd_8544/Makefile
@@ -1,9 +1,14 @@
-include ../Makefile.inc
+include ${CURDIR}/../Makefile.inc
 
 PROG=main
+
+SPI=	$(TOP)/sw_spi
+
 SRCS=$(PROG).c \
      pcd8544.c \
-     $(TOP)/sw_spi/spi.c
+     $(SPI)/spi.c
+
+CFLAGS+= -I${SPI}
 
 CLEANFILES=$(PROG).hex $(PROG).out
 

--- a/src/pcd_8544/main.c
+++ b/src/pcd_8544/main.c
@@ -18,9 +18,10 @@
 #include <avr/io.h>
 
 #include "pcd8544.h"
-#include "sw_spi/spi.h"
+#include "spi.h"
 
 #define DISPLAY_CONTRAST	26
+
 int
 main(void)
 {

--- a/src/pcd_8544/pcd8544.c
+++ b/src/pcd_8544/pcd8544.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 Sebastian Trahm
+ * Copyright (c) 2012-2013 Sebastian Trahm
  * All rights reserved.
  *
  * Permission to use, copy, modify, and distribute this software for any
@@ -18,7 +18,7 @@
 #include <avr/pgmspace.h>
 
 #include "pcd8544.h"
-#include "sw_spi/spi.h"
+#include "spi.h"
 
 #define SFONT_MAX_X	5
 

--- a/src/sw_uart/Makefile
+++ b/src/sw_uart/Makefile
@@ -1,4 +1,4 @@
-include ../Makefile.inc
+include ${CURDIR}/../Makefile.inc
 
 PROG=main
 SRCS=$(PROG).c \


### PR DESCRIPTION
No need to encode the whole path in local includes,
switch to single name reference and let the Makefile
cope with the necessary include path.
Sort include entries and refer to the Makefile.inc
via ${CURDIR}.
