### PR TITLE
Changing ubrr variable to 16 bit

### DIFF
--- a/src/hw_uart/uart.c
+++ b/src/hw_uart/uart.c
@@ -32,8 +32,9 @@ uartInit(uint32_t baudrate)
 	/*
 	 * UBRR - Uart Baud Rate Register
 	 * UBRR = System Clock / Baud Rate * 16 - 1
+	 * UBRR is 12 bit long. Bit 12-15 are currently unused
 	 */
-	uint8_t ubrr = ((F_CPU + baudrate * 8L) / (baudrate * 16L) - 1);
+	uint16_t ubrr = ((F_CPU + baudrate * 8L) / (baudrate * 16L) - 1);
 
 	/* set Baud Rate Register */
 	UBRR0H = (unsigned int)(ubrr >> 8);


### PR DESCRIPTION
Currently it's been 8 bit and no problem was detected.
The Problem will occure only if the ubrr exceeds 256 what happens
starting with a combination of F_CPU=5000000UL and a baudrate
of 2400. (Datasheet p. 210)
